### PR TITLE
feat: possibility to add any affinity rules to the automation job pod…

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,6 +712,7 @@ The ability to specify topologySpreadConstraints is also allowed through `topolo
 | postgres_image_version      | Image version to pull               | 13      |
 | node_selector               | AWX pods' nodeSelector              | ''      |
 | topology_spread_constraints | AWX pods' topologySpreadConstraints | ''      |
+| affinity                    | AWX pods' affinity rules            | ''      |
 | tolerations                 | AWX pods' tolerations               | ''      |
 | annotations                 | AWX pods' annotations               | ''      |
 | postgres_selector           | Postgres pods' nodeSelector         | ''      |
@@ -734,6 +735,27 @@ spec:
       labelSelector:
         matchLabels:
           app.kubernetes.io/name: "<resourcename>"
+  affinity: |
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 1
+        preference:
+          matchExpressions:
+          - key: another-node-label-key
+            operator: In
+            values:
+            - another-node-label-value
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: security
+              operator: In
+              values:
+              - S2
+          topologyKey: topology.kubernetes.io/zone
   tolerations: |
     - key: "dedicated"
       operator: "Equal"

--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -160,6 +160,9 @@ spec:
               topology_spread_constraints:
                 description: topology rule(s) for the pods
                 type: string
+              affinity:
+                description: affinity rule(s) for the pods
+                type: string
               service_labels:
                 description: Additional labels to apply to the service
                 type: string

--- a/roles/installer/templates/deployments/deployment.yaml.j2
+++ b/roles/installer/templates/deployments/deployment.yaml.j2
@@ -379,6 +379,10 @@ spec:
       topologySpreadConstraints:
         {{ topology_spread_constraints | indent(width=8) }}
 {% endif %}
+{% if affinity %}
+      affinity:
+        {{ affinity | indent(width=8) }}
+{% endif %}
 {% if tolerations %}
       tolerations:
         {{ tolerations | indent(width=8) }}


### PR DESCRIPTION
##### SUMMARY
Possibility to add any affinity rules to the automation job pod created by awx-operator

##### ISSUE TYPE
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION
None. Pretty straightforward.

Use case:
I want awx-operator not to schedule automation job pods on the same node where awx-operator is located --> pod with label: `app.kubernetes.io/component: awx`
